### PR TITLE
Dynamically determine msg sizes

### DIFF
--- a/src/wannier/m_wannier_builder.F90
+++ b/src/wannier/m_wannier_builder.F90
@@ -287,7 +287,7 @@ contains
     real(dp), intent(in) ::  anchor_kpt(:)
     integer, optional, intent(in):: anchor_ibands(:)
     complex(dp), pointer :: psik(:,:)
-    character(len = 500):: msg
+    character(len = 10*self%nwann):: msg
     integer :: i
     ABI_MALLOC(self%anchor_ibands, (self%nwann))
     ABI_MALLOC(self%anchor_kpt, (size(anchor_kpt)))
@@ -342,7 +342,7 @@ contains
     real(dp):: weight(self%nband)
     !real(dp), pointer:: evals_anchor(:)
     !type(eigensolver):: esolver
-    character(len = 500):: msg
+    character(len = 10*self%nwann):: msg
     ! find anchor points, by default gamma
     self%anchor_ikpt = self%find_kpoint(self%anchor_kpt)
     ! TODO: add qpt if anchor_ikpt is not found


### PR DESCRIPTION
This prevents sdown from crashing when the numbger of wannier functions is large.